### PR TITLE
fix(note-observation): resolve Bug #2 with lazy mount pattern

### DIFF
--- a/docs/BUG_2_NOTE_OBSERVATION_LAZY_MOUNT.md
+++ b/docs/BUG_2_NOTE_OBSERVATION_LAZY_MOUNT.md
@@ -1,0 +1,165 @@
+# Bug #2 — NoteObservation UPSERT + Lazy Mount Pattern
+
+> **Statut : Résolu (2026-04-28)**
+> Cause : INSERT systématique au lieu d'UPDATE + timing build/query en FlutterFlow.
+> Pattern utilisé : **lazy widget mounting** pour contrôler le timing des Backend Queries.
+
+---
+
+## Problème
+
+À chaque save de NoteObservation :
+- INSERT systématique d'une nouvelle row dans `Dossier_Clinique` au lieu d'UPDATE de la row existante
+- → 20+ rows en doublon pour la même visite (constaté pour Mario : 20 brouillons pour `agenda_id` unique)
+- À l'ouverture de NoteObservation, le brouillon existant n'était **jamais rechargé** → champ note vide à chaque retour
+- Confirmé par les utilisateurs : note "disparaît" après navigation hors/retour de la page
+
+## Cause root (2 problèmes combinés)
+
+### 1. Aucune contrainte UNIQUE sur `Dossier_Clinique`
+La table acceptait N rows pour `(patient_id, agenda_id, statut='brouillon')`. Le bouton "Enregistrer au dossier" faisait `INSERT` à chaque clic, sans check préalable.
+
+### 2. Timing build/query en FlutterFlow
+Quand la page NoteObservation se charge :
+1. Le widget tree se construit immédiatement
+2. `WrapperNoteTexte` se monte → sa Backend Query se déclenche
+3. **Mais l'INSERT n'a pas encore eu lieu** (l'Action Flow `On Page Load` s'exécute en async)
+4. La query retourne `null` → `TF_NoteTexte` créé avec `Initial Value = null` → champ vide
+5. PUIS l'Action Flow se termine, mais `TF_NoteTexte` est **déjà monté** et son controller interne ignore les changements ultérieurs d'`Initial Value`
+
+## Solution
+
+### Migration DB
+
+```sql
+-- Cleanup données de test (22 rows orphelines / doublons)
+DELETE FROM public."Dossier_Clinique";
+
+-- Garantir 1 brouillon max par (patient + agenda)
+CREATE UNIQUE INDEX IF NOT EXISTS dossier_clinique_unique_brouillon
+  ON public."Dossier_Clinique" (patient_id, agenda_id)
+  WHERE statut = 'brouillon';
+```
+
+L'index est **partiel** (`WHERE statut = 'brouillon'`) : il garantit l'unicité des brouillons sans empêcher plusieurs rows `finalise` (cas d'avenants).
+
+### Architecture FlutterFlow — Pattern Lazy Mount
+
+```
+NoteObservation Scaffold
+└── ListView
+    └── Column
+        ├── Photos GridView
+        ├── WrapperNoteTexte                ← Conditional Visibility: pageReady == true
+        │   ├── Backend Query: Dossier_Clinique (Single Row)
+        │   ├── CardNoteTexte
+        │   │   └── TF_NoteTexte             ← Initial Value: query.observations
+        │   └── ... (boutons IA, etc.)
+        └── ...
+```
+
+**Pourquoi lazy mount** : on **empêche** WrapperNoteTexte de se monter avant que l'INSERT ait eu lieu. Comme la Backend Query du widget ne se déclenche qu'au mount, on contrôle son timing.
+
+### Page States
+
+| Nom | Type | Default | Persisted | Rôle |
+|-----|------|---------|-----------|------|
+| `currentBrouillonId` | String (UUID) | vide | OFF | ID du brouillon en cours pour cette page |
+| `pageReady` | Boolean | `false` | OFF | Trigger pour mount lazy de WrapperNoteTexte |
+| `noteTexte` | String | vide | OFF (existant) | Sync pour BoutonAmeliorerIA |
+
+### On Page Load — Action Flow
+
+```
+1. Query Rows existingBrouillon (Dossier_Clinique, filtres patient_id + agenda_id + statut='brouillon' + owner_id)
+
+2. Conditional: existingBrouillon.id Is Set
+   ├── TRUE:
+   │   ├── Update Page State currentBrouillonId = existingBrouillon.First.id
+   │   └── Update Page State noteTexte = existingBrouillon.First.observations
+   └── FALSE:
+       ├── Insert Row Dossier_Clinique (patient_id, agenda_id) → newBrouillon
+       ├── Update Page State currentBrouillonId = newBrouillon.id
+       └── Update Page State noteTexte = newBrouillon.observations
+
+3. API generatePhotoUrls (existant, intact)
+
+4. Update Page State pageReady = true (Rebuild Page = ON)
+   → WrapperNoteTexte devient visible → Backend Query se déclenche → trouve le brouillon
+   → TF_NoteTexte se monte avec Initial Value = observations correctes ✅
+```
+
+### Bouton "Enregistrer au dossier" — refactor
+
+**Avant** (bug) :
+```
+On Tap
+  └── Conditional: noteId Is Set
+        ├── TRUE: Update Row WHERE id=noteId
+        └── FALSE: Insert Row + Update Page State noteId  ← bug: créait des doublons
+```
+
+**Après** (fix) :
+```
+On Tap
+  ├── Update Row(s) Dossier_Clinique
+  │     - Filter: id = currentBrouillonId
+  │     - Set: observations = TF_NoteTexte
+  └── Show Snack Bar
+```
+
+**Garanties** :
+- Au moment du clic, `currentBrouillonId` est toujours défini (set au On Page Load)
+- L'index UNIQUE DB empêche tout doublon même en cas de race condition
+- Plus jamais d'INSERT depuis le bouton — toujours UPDATE
+
+---
+
+## Pattern réutilisable — Lazy Widget Mounting
+
+Ce pattern résout les **timing issues entre Action Flow async et Backend Queries attachées aux widgets**.
+
+### Quand l'utiliser
+
+- Une page doit faire un INSERT/SELECT au load **avant** que des widgets enfants affichent leurs données
+- Les Backend Queries attachées à des widgets ne supportent pas `Refresh Database Request` (erreur "non single time query")
+- Le `TextEditingController` du TextField n'est pas exposé dans Widget State
+
+### Recette
+
+1. **Page State `pageReady`** (Boolean, default `false`)
+2. **Conditional Visibility** sur le widget parent qui contient les queries → `pageReady == true`
+3. **À la fin de l'Action Flow `On Page Load`** : `Update Page State pageReady = true` avec `Rebuild Page = ON`
+4. Le user voit un délai imperceptible (<500ms) entre arrivée sur la page et apparition du widget
+
+### Pourquoi ça marche
+
+- Tant que `pageReady=false`, le widget n'est pas dans le tree → sa Backend Query NE SE DÉCLENCHE PAS
+- Les Action Flow ont le temps de faire INSERT/SELECT et set les Page States
+- Quand `pageReady` passe à `true`, le widget se monte pour la 1ère fois → Backend Query déclenchée → données fraîches → enfants reçoivent leurs `Initial Value` correctement
+
+### Approches qui n'ont PAS marché (documentées pour mémoire)
+
+| Approche | Pourquoi échec |
+|----------|----------------|
+| Update Page State + Rebuild Page = ON | Le `TextEditingController` du TextField conserve son état initial, ignore le rebuild |
+| `Refresh Database Request` sur la query attached widget | Erreur FF : "Refresh database request action called on a widget with no request or that does not allow refresh (such as a non single time query)" |
+| Custom Action Dart avec `controller.text = value` | Le `TextEditingController` de `TF_NoteTexte` n'est pas exposé dans Widget State (selon version FF) |
+| Bind direct sur Backend Query avec controller existant | Même problème : Initial Value lue une seule fois au mount |
+
+---
+
+## Limites connues
+
+- **Délai visuel <500ms** entre arrivée sur la page et apparition de la zone note. Acceptable, peut être masqué par un skeleton si nécessaire en V2.
+- **Statut reste `brouillon`** : actuellement le bouton "Enregistrer au dossier" ne change pas le statut. Si la page Dossier Patient filtre sur `statut='finalise'`, les brouillons n'apparaissent pas. Fix prévu dans sous-sprint suivant.
+- **Auto-save désactivé** : la save reste manuelle via le bouton. Auto-save UPSERT au focus loss ou debounced timer prévu en V2.
+
+---
+
+## Références
+
+- Migration DB : `cleanup_dossier_clinique_dupes_and_add_unique_brouillon_index` (Supabase)
+- Mémoire architecture notes : [`reference_workflow_notes_clinical.md`](../memory/...) — workflow brouillon → finalise
+- Mémoire ProfileSetup : [`reference_profile_setup_dropdowns_et_note_simple.md`](../memory/...) — note = 1 seul champ `observations`
+- Session log : [`docs/sessions/2026-04-28-bug2-upsert-lazy-mount.md`](./sessions/2026-04-28-bug2-upsert-lazy-mount.md)

--- a/docs/sessions/2026-04-28-bug2-upsert-lazy-mount.md
+++ b/docs/sessions/2026-04-28-bug2-upsert-lazy-mount.md
@@ -1,0 +1,92 @@
+# Session 2026-04-28 — Bug #2 UPSERT NoteObservation + Lazy Mount
+
+## Context
+
+Bug #2 du backlog P0 : note disparaît après navigation hors/retour de NoteObservation. Cause : INSERT systématique en DB + timing FlutterFlow build/query.
+
+Sprint long (~10h cumulées sur la journée 28/04, déjà après sprint J2.14 photo-viewer la veille).
+
+## Diagnostic
+
+### État DB initial
+```
+SELECT * FROM Dossier_Clinique;
+-- 22 rows total
+-- 20 doublons pour Mario (patient_id=7, agenda_id=...)
+-- 2 rows orphelines (patient_id=NULL, agenda_id=NULL)
+-- AUCUNE contrainte UNIQUE
+```
+
+### Cause root identifiée
+1. **DB** : aucune contrainte UNIQUE sur `(patient_id, agenda_id, statut)` → INSERT en doublon possible
+2. **FF** : bouton Enregistrer faisait INSERT systématique (pas de Conditional sur "row exists")
+3. **FF timing** : Backend Query attachée à WrapperNoteTexte se déclenche au build, **avant** l'INSERT de l'Action Flow → query retourne null → TextField vide
+
+## Implémentation
+
+### Migration DB
+```sql
+DELETE FROM public."Dossier_Clinique";  -- cleanup test data
+CREATE UNIQUE INDEX dossier_clinique_unique_brouillon
+  ON public."Dossier_Clinique" (patient_id, agenda_id)
+  WHERE statut = 'brouillon';
+```
+
+### FlutterFlow refactor
+
+**Backend Query** : `currentBrouillon` (Single Row) attachée à WrapperNoteTexte avec 4 filtres (patient_id, agenda_id, statut='brouillon', owner_id).
+
+**Page States** :
+- `currentBrouillonId` (String UUID) — pointer vers la row courante
+- `pageReady` (Boolean) — gate pour lazy mount
+
+**On Page Load** :
+1. Query Rows existingBrouillon
+2. Conditional → TRUE: set currentBrouillonId from existing / FALSE: Insert Row + set currentBrouillonId from new
+3. Update Page State noteTexte (sync pour BoutonAmeliorerIA)
+4. API generatePhotoUrls (existant)
+5. Update Page State pageReady = true (Rebuild=ON)
+
+**Bouton Enregistrer** : refactor en simple `Update Row(s) WHERE id=currentBrouillonId` (plus de Conditional).
+
+**WrapperNoteTexte** : Conditional Visibility = `pageReady == true` (lazy mount).
+
+**TF_NoteTexte** : Initial Value = `Backend Query → Dossier_Clinique → observations`.
+
+## Approches abandonnées (documentées pour mémoire)
+
+Plusieurs approches ne fonctionnaient pas en raison du `TextEditingController` interne du TextField qui ignore les changements d'`Initial Value` après mount :
+
+1. **Page State + Rebuild Page** : le controller conserve sa valeur après `setState()`
+2. **Refresh Database Request** : erreur "Refresh database request action called on a widget that does not allow refresh (non single time query)"
+3. **Custom Action Dart avec controller.text = value** : le controller de `TF_NoteTexte` n'est pas exposé dans Widget State (FF 6.6.56)
+
+**La seule approche qui a fonctionné** : empêcher le widget de se monter tant que les données ne sont pas prêtes (= lazy mount via Conditional Visibility).
+
+## Test final
+
+1. ✅ Stop+Run, login, NoteObservation Mario
+2. ✅ TF_NoteTexte affiche "Test bug 3" (le brouillon précédent)
+3. ✅ Pas de doublons en DB (1 row par patient+agenda)
+4. ✅ 0 erreurs FF compilation
+
+## Backlog suivant (issu de cette session)
+
+- **Sous-sprint suivant** : statut `finalise` au save → la note apparaît dans Dossier Patient comme ligne datée
+- **Sous-sprint IA** : harmoniser BoutonAmeliorerIA + Adopter avec `currentBrouillonId` (pour qu'ils touchent la même row)
+- **V2** : auto-save UPSERT (focus loss + debounced timer) — supprimer le bouton manuel
+- **V2** : signature pro intégrée + statut `finalise` immuable (pattern verrouillé dans `reference_workflow_notes_clinical.md`)
+
+## Erreurs résolues bonus
+
+Pendant le sprint, fix de 2 Custom Functions Dart qui bloquaient le compile :
+- `agendaRowsToJson` : type `List<AgendaRow>` → `List<dynamic>` (la classe AgendaRow ayant changé)
+- `buildWeekSummary` : non touché car déjà OK après le fix précédent
+
+## Fichiers touchés
+
+- DB : migration `cleanup_dossier_clinique_dupes_and_add_unique_brouillon_index`
+- FF Studio : page NoteObservation (Action Flow + Page States + Conditional Visibility) — non versionné
+- Custom Function `agendaRowsToJson` — non versionné
+- `docs/BUG_2_NOTE_OBSERVATION_LAZY_MOUNT.md` (créé)
+- `docs/sessions/2026-04-28-bug2-upsert-lazy-mount.md` (ce fichier)


### PR DESCRIPTION
## Summary
- Eliminate INSERT vs UPDATE bug: 20 dups Mario before, 1 row max after
- Fix UI not reflecting DB state: TF_NoteTexte was vide après reload
- Add UNIQUE partial index DB: dossier_clinique_unique_brouillon
- Implement lazy widget mounting pattern: pageReady + Conditional Visibility

## Pattern réutilisable
docs/BUG_2_NOTE_OBSERVATION_LAZY_MOUNT.md — résout les timing issues entre Action Flow async et Backend Queries attachées aux widgets en FF.

## Test plan
- [x] Stop+Run + Mario NoteObservation → note "Test bug 3" réapparaît
- [x] DB check : 1 seul row par (patient_id, agenda_id) en brouillon
- [x] 0 erreurs FF compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)